### PR TITLE
Extension should not follow logout links

### DIFF
--- a/check.js
+++ b/check.js
@@ -108,7 +108,7 @@ chrome.extension.onMessage.addListener(
       blacklisted = false;
       var lowerCaseURL = url.toLowerCase();
 
-      if (url.length > 0 && url.startsWith('http') && (rel !== "nofollow") && (!lowerCaseURL.contains('logout')){
+      if (url.length > 0 && url.startsWith('http') && (rel !== "nofollow") && (!lowerCaseURL.contains('logout'))){
         for (var b = 0; b < blacklist.length; b++)
         {
           if (blacklist[b] !== "" && url.contains(blacklist[b])){

--- a/check.js
+++ b/check.js
@@ -107,7 +107,7 @@ chrome.extension.onMessage.addListener(
       var rel = link.rel;
       blacklisted = false;
 
-      if (url.length > 0 && url.startsWith('http') && rel !== "nofollow" && !url.contains('logout')){
+      if (url.length > 0 && url.startsWith('http') && rel !== "nofollow" && !url.contains('logout') && !url.contains('Logout'){
         for (var b = 0; b < blacklist.length; b++)
         {
           if (blacklist[b] !== "" && url.contains(blacklist[b])){

--- a/check.js
+++ b/check.js
@@ -106,8 +106,9 @@ chrome.extension.onMessage.addListener(
       var url = link.href;
       var rel = link.rel;
       blacklisted = false;
+      var lowerCaseURL = url.toLowerCase();
 
-      if (url.length > 0 && url.startsWith('http') && rel !== "nofollow" && !url.contains('logout') && !url.contains('Logout'){
+      if (url.length > 0 && url.startsWith('http') && (rel !== "nofollow") && (!lowerCaseURL.contains('logout')){
         for (var b = 0; b < blacklist.length; b++)
         {
           if (blacklist[b] !== "" && url.contains(blacklist[b])){

--- a/check.js
+++ b/check.js
@@ -107,7 +107,7 @@ chrome.extension.onMessage.addListener(
       var rel = link.rel;
       blacklisted = false;
 
-      if (url.length > 0 && url.startsWith('http') && rel !== "nofollow"){
+      if (url.length > 0 && url.startsWith('http') && rel !== "nofollow" && !url.contains('logout')){
         for (var b = 0; b < blacklist.length; b++)
         {
           if (blacklist[b] !== "" && url.contains(blacklist[b])){


### PR DESCRIPTION
I modified the logic to keep the extension from following links with "Logout, "logout," or any other uppercase or lowercase variety of "logout" in them.