### PR TITLE
hashtag fragID matches element with matching id or name attribute

### DIFF
--- a/background.js
+++ b/background.js
@@ -83,8 +83,9 @@ function check(url, callback) {
                 if(url.indexOf("#")!=-1){
                     var parser = new DOMParser ();
                     var responseDoc = parser.parseFromString (xhr.responseText, "text/html");
-                    log (responseDoc.getElementById(url.substring(url.indexOf("#")+1,url.length)));
-                    if(responseDoc.getElementById(url.substring(url.indexOf("#")+1,url.length))){
+                    var fragID = url.substring(url.indexOf("#")+1,url.length);
+                    log (responseDoc.getElementById(fragID) || responseDoc.getElementsByName(fragID));
+                    if( responseDoc.getElementById(fragID) || responseDoc.getElementsByName(fragID) ){
                         // Element with id that matches hashtag was found
                         if(getItem("cache")=='true'){
                             indexedDBHelper.addLink(url, xhr.status);


### PR DESCRIPTION
Hi there,

First off I just wanted to say I think this chrome extension is really great.

We were getting some false negative results for URLs that contain hashtag URL fragments because the HTML in question uses "name" instead of "id" attributes to match the fragment id.

According to HTML 5 spec I believe either "id" or "name" attributes for URL fragments are acceptable (http://www.w3.org/html/wg/drafts/html/master/browsers.html#scroll-to-fragid)

I think this would just be a small tweak to the code as below.