### PR TITLE
Show options page on install

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,6 +44,16 @@ chrome.browserAction.onClicked.addListener(function (tab) {
     });
 });
 
+chrome.runtime.onInstalled.addListener(function(details){
+    if(details.reason == "install"){
+        chrome.tabs.create({url: "options.html?newinstall=yes"});
+    }
+    else if(details.reason == "update"){
+        var thisVersion = chrome.runtime.getManifest().version;
+        console.log("Updated from " + details.previousVersion + " to " + thisVersion + "!");
+    }
+});
+
 function onRequest(request, sender, callback) {
     if (request.action == "check") {
         if (request.url) {


### PR DESCRIPTION
Shows the options page on new install.  This way, users are guaranteed to see the configuration options at least once and therefore know they are available.
https://developer.chrome.com/extensions/runtime#event-onInstalled
